### PR TITLE
Remove Google API client from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
 		"composer/installers": "^1.4",
 		"nesbot/carbon": "^1.0",
 		"a5hleyrich/wp-queue": "^1.3",
-		"google/apiclient": "^2.0",
 		"johnbillion/extended-cpts": "^4.2",
 		"illuminate/filesystem": "^5.8",
 		"illuminate/translation": "^5.8",


### PR DESCRIPTION
Add back only when needed in a theme.